### PR TITLE
Add missing test for cosine correction

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -177,7 +177,7 @@ clusterMuscadet <- function(x, # muscadet object
         # for version <=2.1, Rfast returns a similarity matrix for cosine with 0
         # values in diagonal. The result should be converted into distance.
         # See https://github.com/RfastOfficial/Rfast/issues/119 for more info
-        if(packageVersion("Rfast") <= "2.1.0") {
+        if(dist_method == "cosine" & packageVersion("Rfast") <= "2.1.0") {
             diag(dist) <- 1
             dist <- 1-dist
         }


### PR DESCRIPTION
The previous PR introduced a bug because we weren’t testing for the dist_method before performing the correction for cosine. Euclidian is thus currently broken.

This fixes the issue.