### PR TITLE
Implement homozygous filter in cnaCalling()

### DIFF
--- a/R/cnaCalling.R
+++ b/R/cnaCalling.R
@@ -666,6 +666,26 @@ aggregateCounts <- function(x,
 #' @param dipLogR Optional. Numeric value specifying an expected log ratio for
 #'   diploid regions to use for the analysis. If `NULL`, by default, the diploid
 #'   log ratio is estimated automatically from the data.
+#' @param filter.homozygous Logical. If `TRUE`, filters out homozygous allelic
+#'   positions in non-deletion regions, as they cause noise in the allelic
+#'   imbalance signal. Recommended when allele positions are derived
+#'   from a common SNPs database rather than individual-specific heterozygous
+#'   positions called from bulk sequencing. Default is `TRUE`.
+#' @param vaf.thresh Threshold applied to the transformed VAF (`VAF.abs = 0.5 -
+#'   |VAF - 0.5|`) below which a position is considered homozygous and filtered
+#'   out within non-deletion regions (used when `filter.homozygous = TRUE`)
+#'   (default: `0.1`).
+#' @param vafmean.win Window size for computing the running mean of VAF per
+#'   cluster and per chromosome, used to assess the local allelic context of
+#'   each position (used when `filter.homozygous = TRUE`) (default: `50`). If greater than 1, interpreted
+#'   as an absolute number of positions. If between `0` and `1`,
+#'   interpreted as a fraction of the total positions on the chromosome, with a
+#'   minimum of 10 positions.
+#' @param vafmean.thresh Running mean VAF threshold used to identify deletion
+#'   regions (used when `filter.homozygous = TRUE`) (default: `0.02`). Positions
+#'   where the local VAF running mean is below this threshold are considered to
+#'   be in a deletion region and are excluded from homozygous filtering to avoid
+#'   removing signal.
 #' @param quiet Logical. If `TRUE`, suppresses informative messages during
 #'   execution. Default is `FALSE`.
 #'
@@ -740,6 +760,31 @@ aggregateCounts <- function(x,
 #'   \item \code{ploidy}: Ploidy used for the CNA analysis.
 #' }
 #'
+#' @details
+#' ## Homozygous position filtering
+#'
+#' When `filter.homozygous = TRUE`, homozygous allelic positions are removed
+#' prior to CNA calling to reduce noise in the allelic imbalance signal. This
+#' filter is particularly relevant when allele positions for allele counts are derived from a common
+#' SNPs database, which includes positions that are
+#' homozygous in the individual, unlike heterozygous positions specifically
+#' called from individual bulk sequencing data.
+#'
+#' For each cluster and each chromosome, a running mean of VAF is computed over
+#' a window of `vafmean.win` positions. This local VAF context is used to
+#' distinguish two types of regions:
+#'
+#' - **Non-deletion regions** (running mean VAF `>= vafmean.thresh`): positions
+#' with a VAF below `vaf.thresh` are considered homozygous and filtered out, as
+#' they contribute noise to the allelic imbalance signal without carrying
+#' informative heterozygous signal. The threshold is applied to a transformed
+#' VAF defined as `VAF.abs = 0.5 - |VAF - 0.5|`, which measures the deviation
+#' from homozygosity.
+#' - **Deletion regions** (running mean VAF `< vafmean.thresh`): the filter is
+#' not applied, as most positions are expected to be homozygous due to the
+#' deletion-induced allelic imbalance. Filtering here would remove genuine
+#' signal rather than noise.
+#'
 #' @seealso [assignClusters()], [aggregateCounts()],[preProcSample2()]
 #'
 #' @source This function uses several functions from the
@@ -771,6 +816,7 @@ aggregateCounts <- function(x,
 #' @import facets
 #' @import pctGCdata
 #' @importFrom GenomicRanges GRanges
+#' @importFrom caTools runmean
 #' @importFrom stats na.omit
 #' @importFrom rlang .data
 #'
@@ -784,6 +830,17 @@ aggregateCounts <- function(x,
 #'
 #' exdata_muscadet <- cnaCalling(
 #'     exdata_muscadet,
+#'     omics.coverage = "ATAC",
+#'     depthmin.a.clusters = 3, # set low thresholds for example data
+#'     depthmin.c.clusters = 5,
+#'     depthmin.a.allcells = 3,
+#'     depthmin.c.allcells = 5,
+#'     depthmin.c.nor = 0
+#' )
+#'
+#' exdata_muscadet <- cnaCalling(
+#'     exdata_muscadet,
+#'     filter.homozygous = FALSE, # without homozygous filter
 #'     omics.coverage = "ATAC",
 #'     depthmin.a.clusters = 3, # set low thresholds for example data
 #'     depthmin.c.clusters = 5,
@@ -813,6 +870,10 @@ cnaCalling <- function(
         minoverlap = 1e6,
         ploidy = "auto",
         dipLogR = NULL,
+        filter.homozygous = TRUE,
+        vaf.thresh = 0.1,
+        vafmean.thresh = 0.02,
+        vafmean.win = 50,
         quiet = FALSE
 ) {
 
@@ -835,7 +896,10 @@ cnaCalling <- function(
         is.numeric(cval1),
         is.numeric(cval2),
         is.numeric(clonal.thresh),
-        is.numeric(dist.breakpoints)
+        is.numeric(dist.breakpoints),
+        is.numeric(vaf.thresh),
+        is.numeric(vafmean.thresh),
+        is.numeric(vafmean.win)
     )
     stopifnot(
         "The `ploidy` argument must be either numeric or 'median' or 'auto'." =
@@ -934,6 +998,74 @@ cnaCalling <- function(
 
     allelic_rcmat <- na.omit(allelic_rcmat)
 
+    # ==========================================================================
+    # Filter homozygous position from common SNP
+
+    filter_homozygous <- function(df,
+                                  vaf.thresh = 0.1,
+                                  vafmean.thresh = 0.02,
+                                  vafmean.win = 50) {
+        # Compute VAF per cluster
+        df <- df %>%
+            dplyr::mutate(VAF = .data$TUM.RD / .data$TUM.DP,
+                          VAF.abs = 0.5 - abs(.data$VAF - 0.5))
+
+        # Compute running means per chromosome per cluster
+        if (vafmean.win > 1) {
+            df <- df %>%
+                dplyr::group_by(.data$cluster, .data$Chromosome) %>%
+                dplyr::mutate(
+                    runm = caTools::runmean(
+                        .data$VAF.abs,
+                        k = vafmean.win,
+                        endrule = "mean",
+                        align = "center"
+                    )
+                )
+        }
+        else if (vafmean.win > 0 & vafmean.win <= 1) {
+            df <- df %>%
+                dplyr::group_by(.data$cluster, .data$Chromosome) %>%
+                dplyr::mutate(runm = caTools::runmean(
+                    .data$VAF.abs,
+                    k = max(10, floor(vafmean.win * dplyr::n())),
+                    endrule = "mean",
+                    align = "center"
+                )) %>%
+                dplyr::ungroup()
+        }
+
+        # Filter homozygous positions
+        df <- df %>%
+            dplyr::filter((.data$VAF.abs > vaf.thresh |
+                               .data$runm < vafmean.thresh)) %>%
+            dplyr::select(-c("VAF", "VAF.abs", "runm"))
+
+        return(as.data.frame(df))
+    }
+
+    # ==========================================================================
+
+    if (filter.homozygous) {
+        msg("Filtering homozygous positions...")
+        n_before  <- nrow(allelic_rcmat)
+
+        allelic_rcmat <- filter_homozygous(
+            allelic_rcmat,
+            vaf.thresh = vaf.thresh,
+            vafmean.thresh = vafmean.thresh,
+            vafmean.win = vafmean.win
+        )
+        n_after <- nrow(allelic_rcmat)
+        n_removed <- n_before - n_after
+
+        msg(paste0(
+            "Homozygous filter: ",
+            n_removed, " / ", n_before,
+            " positions removed, ",
+            n_after, " positions retained."
+        ))
+    }
     # ==========================================================================
     # Process coverage counts
 
@@ -1163,6 +1295,28 @@ cnaCalling <- function(
         dplyr::arrange(.data$Chromosome, .data$Position, .data$cluster)
 
     allelic_rcmat_allcells <- na.omit(allelic_rcmat_allcells)
+
+    if (filter.homozygous) {
+        msg("Filtering homozygous positions of all cells...")
+        n_before  <- nrow(allelic_rcmat_allcells)
+
+        allelic_rcmat_allcells <- filter_homozygous(
+            df = allelic_rcmat_allcells,
+            vaf.thresh = vaf.thresh,
+            vafmean.thresh = vafmean.thresh,
+            vafmean.win = vafmean.win
+        )
+
+        n_after <- nrow(allelic_rcmat_allcells)
+        n_removed <- n_before - n_after
+
+        message(paste0(
+            "Homozygous filter: ",
+            n_removed, " / ", n_before,
+            " positions removed, ",
+            n_after, " positions retained."
+        ))
+    }
 
     msg("Allelic positions kept: ", nrow(allelic_rcmat_allcells))
 

--- a/man/cnaCalling.Rd
+++ b/man/cnaCalling.Rd
@@ -42,6 +42,10 @@ cnaCalling(
   minoverlap = 1e+06,
   ploidy = "auto",
   dipLogR = NULL,
+  filter.homozygous = TRUE,
+  vaf.thresh = 0.1,
+  vafmean.thresh = 0.02,
+  vafmean.win = 50,
   quiet = FALSE
 )
 }
@@ -115,6 +119,29 @@ value (default: \code{"auto"}).}
 \item{dipLogR}{Optional. Numeric value specifying an expected log ratio for
 diploid regions to use for the analysis. If \code{NULL}, by default, the diploid
 log ratio is estimated automatically from the data.}
+
+\item{filter.homozygous}{Logical. If \code{TRUE}, filters out homozygous allelic
+positions in non-deletion regions, as they cause noise in the allelic
+imbalance signal. Recommended when allele positions are derived
+from a common SNPs database rather than individual-specific heterozygous
+positions called from bulk sequencing. Default is \code{TRUE}.}
+
+\item{vaf.thresh}{Threshold applied to the transformed VAF (\verb{VAF.abs = 0.5 - |VAF - 0.5|}) below which a position is considered homozygous and filtered
+out within non-deletion regions (used when \code{filter.homozygous = TRUE})
+(default: \code{0.1}).}
+
+\item{vafmean.thresh}{Running mean VAF threshold used to identify deletion
+regions (used when \code{filter.homozygous = TRUE}) (default: \code{0.02}). Positions
+where the local VAF running mean is below this threshold are considered to
+be in a deletion region and are excluded from homozygous filtering to avoid
+removing signal.}
+
+\item{vafmean.win}{Window size for computing the running mean of VAF per
+cluster and per chromosome, used to assess the local allelic context of
+each position (used when \code{filter.homozygous = TRUE}) (default: \code{50}). If greater than 1, interpreted
+as an absolute number of positions. If between \code{0} and \code{1},
+interpreted as a fraction of the total positions on the chromosome, with a
+minimum of 10 positions.}
 
 \item{quiet}{Logical. If \code{TRUE}, suppresses informative messages during
 execution. Default is \code{FALSE}.}
@@ -195,6 +222,33 @@ Performs copy number alteration (CNA) analysis on a
 \code{\link[=muscadet-class]{muscadet}} object by processing allelic and coverage counts
 across clusters and evaluating cell fractions and copy numbers.
 }
+\details{
+\subsection{Homozygous position filtering}{
+
+When \code{filter.homozygous = TRUE}, homozygous allelic positions are removed
+prior to CNA calling to reduce noise in the allelic imbalance signal. This
+filter is particularly relevant when allele positions for allele counts are derived from a common
+SNPs database, which includes positions that are
+homozygous in the individual, unlike heterozygous positions specifically
+called from individual bulk sequencing data.
+
+For each cluster and each chromosome, a running mean of VAF is computed over
+a window of \code{vafmean.win} positions. This local VAF context is used to
+distinguish two types of regions:
+\itemize{
+\item \strong{Non-deletion regions} (running mean VAF \verb{>= vafmean.thresh}): positions
+with a VAF below \code{vaf.thresh} are considered homozygous and filtered out, as
+they contribute noise to the allelic imbalance signal without carrying
+informative heterozygous signal. The threshold is applied to a transformed
+VAF defined as \verb{VAF.abs = 0.5 - |VAF - 0.5|}, which measures the deviation
+from homozygosity.
+\item \strong{Deletion regions} (running mean VAF \verb{< vafmean.thresh}): the filter is
+not applied, as most positions are expected to be homozygous due to the
+deletion-induced allelic imbalance. Filtering here would remove genuine
+signal rather than noise.
+}
+}
+}
 \examples{
 library("facets")
 
@@ -203,6 +257,17 @@ library("facets")
 
 exdata_muscadet <- cnaCalling(
     exdata_muscadet,
+    omics.coverage = "ATAC",
+    depthmin.a.clusters = 3, # set low thresholds for example data
+    depthmin.c.clusters = 5,
+    depthmin.a.allcells = 3,
+    depthmin.c.allcells = 5,
+    depthmin.c.nor = 0
+)
+
+exdata_muscadet <- cnaCalling(
+    exdata_muscadet,
+    filter.homozygous = FALSE, # without homozygous filter
     omics.coverage = "ATAC",
     depthmin.a.clusters = 3, # set low thresholds for example data
     depthmin.c.clusters = 5,

--- a/tests/testthat/test-cnaCalling.R
+++ b/tests/testthat/test-cnaCalling.R
@@ -72,12 +72,71 @@ test_that("cnaCalling() returns a correct output", {
                                depthmin.a.allcells = 3,
                                depthmin.c.allcells = 5,
                                depthmin.c.nor = 1,
+                               filter.homozygous = FALSE,
                                quiet = TRUE)
 
     expect_s4_class(muscadet_cna, "muscadet")
     expect_length(muscadet_cna$cnacalling, 20)
 })
 
+
+test_that("cnaCalling() returns a correct output when filter.homozygous = TRUE", {
+
+    data("exdata_muscadet", package = "muscadet")
+
+    muscadet_cna <- cnaCalling(exdata_muscadet,
+                               depthmin.a.clusters = 3, # set low thresholds for example data
+                               depthmin.c.clusters = 5,
+                               depthmin.a.allcells = 3,
+                               depthmin.c.allcells = 5,
+                               depthmin.c.nor = 1,
+                               vafmean.win = 5,
+                               quiet = TRUE)
+
+    expect_s4_class(muscadet_cna, "muscadet")
+    expect_length(muscadet_cna$cnacalling, 20)
+})
+
+
+test_that("cnaCalling() returns less positions when filter.homozygous = TRUE", {
+
+    data("exdata_muscadet", package = "muscadet")
+
+    muscadet_cna <- cnaCalling(exdata_muscadet,
+                               depthmin.a.clusters = 3, # set low thresholds for example data
+                               depthmin.c.clusters = 5,
+                               depthmin.a.allcells = 3,
+                               depthmin.c.allcells = 5,
+                               depthmin.c.nor = 1,
+                               filter.homozygous = FALSE,
+                               quiet = TRUE)
+
+    muscadet_cna_filtered <- cnaCalling(exdata_muscadet,
+                               depthmin.a.clusters = 3,
+                               depthmin.c.clusters = 5,
+                               depthmin.a.allcells = 3,
+                               depthmin.c.allcells = 5,
+                               depthmin.c.nor = 1,
+                               vafmean.win = 5,
+                               quiet = TRUE)
+
+    expect_true(nrow(muscadet_cna_filtered$cnacalling$combined.counts.filtered)
+                    <= nrow(muscadet_cna$cnacalling$combined.counts.filtered))
+})
+
+test_that("cnaCalling() must have a positive vafmean.win value when filter.homozygous = TRUE",{
+
+    data("exdata_muscadet", package = "muscadet")
+
+   expect_error(muscadet_cna <- cnaCalling(exdata_muscadet,
+                               depthmin.a.clusters = 3, # set low thresholds for example data
+                               depthmin.c.clusters = 5,
+                               depthmin.a.allcells = 3,
+                               depthmin.c.allcells = 5,
+                               depthmin.c.nor = 1,
+                               vafmean.win = -1,
+                               quiet = TRUE))
+})
 
 test_that("preProcSample2() returns a correct ouput", {
 

--- a/vignettes/data-prep.qmd
+++ b/vignettes/data-prep.qmd
@@ -134,7 +134,22 @@ The output of `snp-pileup` can be filtered on depth and allele frequency to keep
 
 See [FACETS snp-pileup documentation](https://github.com/mskcc/facets/blob/master/inst/extcode/README.txt).
 
+::: {.callout-important}
+When using individual-specific heterozygous positions from bulk sequencing, set `filter.homozygous = FALSE` in `cnaCalling()`. 
+Allele count positions are already restricted to heterozygous calls and the filter is not needed.
+:::
+
 ### Panels of common SNPs
+
+When individual bulk sequencing data is not available, allele counts can be derived from a reference panel of common SNPs. 
+We recommend using the **Common dbSNP 155** track (hg38) from UCSC ([UCSC Table Browser](https://genome.ucsc.edu/cgi-bin/hgTables)), 
+which contains variants and their associated minor allele frequencies (MAF), filtered for single nucleotide variants (SNVs) only. 
+
+We recommend filtering positions with a MAF below 0.2, based on the highest MAF across the three projects 
+**1000 Genomes**, **TOPMED**, and **gnomAD**, to ensure sufficient heterozygosity. 
+The resulting common SNP table should follow a VCF-like format with one row per position and columns `CHROM`, `POS`, `ID`, `REF`, `ALT`.
+
+Other common SNP databases can also be used as an alternative:
 
 * [gnomAD](https://gnomad.broadinstitute.org/) database: [data here](https://gnomad.broadinstitute.org/downloads)
 * [1000G](https://www.internationalgenome.org/) database: [data here](https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/working/20220422_3202_phased_SNV_INDEL_SV/)

--- a/vignettes/muscadet.qmd
+++ b/vignettes/muscadet.qmd
@@ -446,6 +446,13 @@ exdata_muscadet <- cnaCalling(
 )
 ```
 
+::: {.callout-important}
+Set `filter.homozygous = FALSE` when allele counts are derived from individual-specific heterozygous positions called from bulk sequencing data.
+This filter is applied prior to CNA calling to reduce noise in the allelic imbalance signal caused by homozygous positions. It is specifically designed
+for allele counts positions derived from a common SNPs database, which includes homozygous positions by definition, and is not needed when allelic positions
+are already restricted to heterozygous calls.
+:::
+
 ::: {.callout-note}
 The default minimum depth (`depthmin.[...]`) filters may not be suitable for all datasets. It is recommended to inspect your data and adjust these parameters accordingly.
 :::


### PR DESCRIPTION
Adds an optional filter for homozygous allele positions in `cnaCalling()`, designed for use cases where allele counts are derived from a common SNPs database rather than individual-specific heterozygous positions called from bulk sequencing data.

- Add `filter.homozygous` argument to `cnaCalling()` (default: `TRUE`) to filter homozygous positions in non-deletion regions, reducing noise in the allelic imbalance signal.
- Add supporting arguments `vaf.thresh`, `vafmean.win`, and `vafmean.thresh` to control filtering behaviour.
- Add tests.
- Update documentation of `cnaCalling()`.
- Update documentation in vignettes.

